### PR TITLE
Added fastlane

### DIFF
--- a/KeitaiWaniKani/Util/DatabaseManager.swift
+++ b/KeitaiWaniKani/Util/DatabaseManager.swift
@@ -18,7 +18,11 @@ public class DatabaseManager {
     
     static var secureAppGroupPersistentStoreURL: URL = {
         let fm = FileManager.default
-        let directory = fm.containerURL(forSecurityApplicationGroupIdentifier: "group.uk.me.laverty.KeitaiWaniKani")!
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+            fatalError("Can't find bundle identifier")
+        }
+        let groupIdentifier = "group.\(bundleIdentifier)"
+        let directory = fm.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)!
         return directory.appendingPathComponent("WaniKaniData.sqlite")
     }()
     

--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ Features:
 * Lists upcoming reviews in the review timeline
 * Progress for current-level radicals and kanji, including time until next review and quickest time to Guru
 * Notification Centre widget
+
+## How to get started
+Since the project uses an app extension / widget, you'd have to create a new App Group, AppID on the Apple developer portal, and change the app bundle identifiers in the main target and app extension. However, a [fastlane](https://github.com/fastlane/fastlane) lane has been be prepared to take care of all that for you. Here's what you need to do:
+- Have a registered Apple Developer Account.
+- Install [fastlane](https://github.com/fastlane/fastlane)
+- Clone / download the project
+- Open the file in "fastlane/Fastfile"
+- In the Fastfile, set your own bundle identifier and Apple ID at the very top of the document
+- Run `fastlane setupID` using the command line
+- Select your signing identity for the `AlliCrab` and `WaniKaniStudyQueueWidget` targets.
+- You should now be able to run the project on your device!
+
+You can use `fastlane resetID` to reset the bundle identifiers to the default values again, which may be useful if you want to submit pull requests without your custom bundle identifiers.
+
+You can run `git update-index --assume-unchanged fastlane/Fastfile` if you want to keep changes of Fastfile locally without having to push them. (`Use git update-index --no-assume-unchanged fastlane/Fastfile` to undo this.)

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,5 @@
+app_identifier ENV["APP_IDENTIFIER"]
+apple_id ENV["APPLE_ID"]
+
+# you can even provide different app identifiers, Apple IDs and team names per lane:
+# More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,126 @@
+# Must change
+ENV["APP_IDENTIFIER"] = "uk.me.laverty.KeitaiWaniKani" # set your custom bundle identifier
+ENV["APPLE_ID"] = "yourEmail@example.com" # set your Apple ID email
+
+# Customizable
+appIDAppName = "AlliCrab"
+appGroupName = "AlliCrab App Group"
+
+# default values - Don't change these values
+waniKaniStudyQueueWidgetAppend = ".WaniKaniStudyQueueWidget"
+groupPrepend = "group."
+
+defaultAlliCrabIdentifier = "uk.me.laverty.KeitaiWaniKani"
+defaultWaniKaniStudyQueueWidgetIdentifier = defaultAlliCrabIdentifier + waniKaniStudyQueueWidgetAppend
+defaultGroupIdentifier = groupPrepend + defaultAlliCrabIdentifier
+
+alliCrabInfoPlist = "KeitaiWaniKani/Info.plist"
+waniKaniStudyQueueWidgetInfoPlist = "WaniKaniStudyQueueWidget/Info.plist"
+alliCrabEntitlementsFile = "KeitaiWaniKani/KeitaiWaniKani.entitlements"
+waniKaniStudyQueueWidgetEntitlementsFile = "WaniKaniStudyQueueWidget/WaniKaniStudyQueueWidget.entitlements"
+# end - default values
+
+app_identifier = ENV["APP_IDENTIFIER"]
+
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/fastlane/docs
+# All available actions: https://docs.fastlane.tools/actions
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version "2.37.0"
+
+default_platform :ios
+
+platform :ios do
+  
+  desc "Create AppID, App Groups, and change Bundle Identifiers, entitlements"
+  desc "This will create and use the new AppID, App Groups on the Apple developer portal 
+  and change Bundle Identifiers for this project which is necessary to run the project on your side."
+  lane :setupID do
+  	userWaniKaniStudyQueueWidgetIdentifier = app_identifier + waniKaniStudyQueueWidgetAppend
+  	userGroupIdentifier = groupPrepend + app_identifier
+
+	# Create AppID
+  	produce(
+  		app_identifier: "#{app_identifier}",
+  		app_name: "#{appIDAppName}",
+  		skip_itc: true,
+
+  		enable_services: {
+  			app_group: "on"
+  		}
+  	)
+
+  	# create App Group
+  	sh "fastlane produce group -g #{userGroupIdentifier} -n #{appGroupName}"
+  	sh "fastlane produce associate_group -a #{app_identifier} #{userGroupIdentifier}"
+
+  	update_app_group_identifiers(
+		  entitlements_file: "#{alliCrabEntitlementsFile}",
+		  app_group_identifiers: ["#{userGroupIdentifier}"]
+    )
+
+    update_app_group_identifiers(
+      entitlements_file: "#{waniKaniStudyQueueWidgetEntitlementsFile}",
+      app_group_identifiers: ["#{userGroupIdentifier}"]
+    )
+
+  	# Change CFBundleIdentifier for 'AlliCrab' target
+  	update_app_identifier(
+  		plist_path: alliCrabInfoPlist,
+  		app_identifier: app_identifier
+  	)
+
+	# Change CFBundleIdentifier for 'WaniKaniStudyQueueWidget' extension
+  	update_app_identifier(
+  		plist_path: waniKaniStudyQueueWidgetInfoPlist,
+  		app_identifier: userWaniKaniStudyQueueWidgetIdentifier
+  	)
+
+  end
+
+  desc "Reset to default AppID, App Groups, and Bundle identifiers"
+  desc "This will reset the identifiers to the default values as on the Github repository. 
+  Does not remove the created AppIDs or App Groups from the developer portal."
+  lane :resetID do 
+
+  	update_app_group_identifiers(
+		  entitlements_file: "#{alliCrabEntitlementsFile}",
+		  app_group_identifiers: ["#{defaultGroupIdentifier}"]
+	  )
+
+    update_app_group_identifiers(
+      entitlements_file: "#{waniKaniStudyQueueWidgetEntitlementsFile}",
+      app_group_identifiers: ["#{defaultGroupIdentifier}"]
+    )
+
+  	# Reset CFBundleIdentifier for 'AlliCrab' target
+  	update_app_identifier(
+  		plist_path: alliCrabInfoPlist,
+  		app_identifier: defaultAlliCrabIdentifier
+  	)
+
+	# Reset CFBundleIdentifier for 'WaniKaniStudyQueueWidget' extension
+  	update_app_identifier(
+  		plist_path: waniKaniStudyQueueWidgetInfoPlist,
+  		app_identifier: defaultWaniKaniStudyQueueWidgetIdentifier
+  	)
+
+  end
+  
+end
+
+
+# More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
+# All available actions: https://docs.fastlane.tools/actions
+
+# fastlane reports which actions are used. No personal data is recorded. 
+# Learn more at https://github.com/fastlane/fastlane#metrics

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,54 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+## Choose your installation method:
+
+<table width="100%" >
+<tr>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
+<th width="33%">Installer Script</td>
+<th width="33%">Rubygems</td>
+</tr>
+<tr>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
+</tr>
+<tr>
+<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>sudo gem install fastlane -NV</code></td>
+</tr>
+</table>
+
+# Available Actions
+## iOS
+### ios setupID
+```
+fastlane ios setupID
+```
+Create AppID, App Groups, and change Bundle Identifiers, entitlements
+
+This will create and use the new AppID, App Groups on the Apple developer portal 
+  and change Bundle Identifiers for this project which is necessary to run the project on your side.
+### ios resetID
+```
+fastlane ios resetID
+```
+Reset to default AppID, App Groups, and Bundle identifiers
+
+This will reset the identifiers to the default values as on the Github repository. 
+  Does not remove the created AppIDs or App Groups from the developer portal.
+
+----
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
Added fastlane to the project and lanes to help anyone cloning the project to get up and running quickly.

Because this project uses app extensions and the App Groups entitlement, you would usually have to:
- create AppIDs in Apple developer portal 
- create App Groups in Apple developer portal 
- change main target bundle identifier
- change main target group entitlement identifier
- change app extension bundle identifier
- change app extension group entitlement identifier

Now you can simply run `fastlane setupID` to do all of the above.

Readme has also been updated with detailed instructions.