### PR TITLE
Threading fix

### DIFF
--- a/AlliCrab/App Operations/GetDashboardDataOperation.swift
+++ b/AlliCrab/App Operations/GetDashboardDataOperation.swift
@@ -99,8 +99,10 @@ final class GetDashboardDataOperation: GroupOperation, ProgressReporting {
                     guard let studyQueue = maybeStudyQueue else { return }
                     
                     DDLogDebug("Badging app icon: \(studyQueue.reviewsAvailable)")
-                    let application = UIApplication.shared
-                    application.applicationIconBadgeNumber = studyQueue.reviewsAvailable
+                    DispatchQueue.main.sync {
+                        let application = UIApplication.shared
+                        application.applicationIconBadgeNumber = studyQueue.reviewsAvailable
+                    }
                 }
             ))
         


### PR DESCRIPTION
On iOS 11 beta, I get a crash complaining that `[UIApplication setApplicationIconBadgeNumber:]` should be called on the main thread.