### PR TITLE
Mapping character on Kanji and Radical to characters as per breaking API change

### DIFF
--- a/WaniKaniKit/Model/Kanji.swift
+++ b/WaniKaniKit/Model/Kanji.swift
@@ -19,7 +19,7 @@ public struct Kanji: ResourceCollectionItemData {
         case level
         case createdAt = "created_at"
         case slug
-        case character
+        case character = "characters"
         case meanings
         case readings
         case componentSubjectIDs = "component_subject_ids"

--- a/WaniKaniKit/Model/Radical.swift
+++ b/WaniKaniKit/Model/Radical.swift
@@ -28,7 +28,7 @@ public struct Radical: ResourceCollectionItemData {
         case level
         case createdAt = "created_at"
         case slug
-        case character
+        case character = "characters"
         case characterImages = "character_images"
         case meanings
         case documentURL = "document_url"


### PR DESCRIPTION
Just made a small fix which stopped the app from working, due a recent v2 API breaking change as per https://community.wanikani.com/t/api-v2-alpha-documentation/18987/358

This might not be the way you'd prefer to fix it (wasn't sure if you would rename the table fields, although that would require some migration of the data I guess), but obviously feel free to discard if you don't want to use this, it's a tiny patch :)

P.S. Thanks for making the app in the first place, it's really great.