### PR TITLE
Hardcode a return for level to allow other data to load

### DIFF
--- a/WaniKaniKit/Database/Coder/Assignment+DatabaseCodable.swift
+++ b/WaniKaniKit/Database/Coder/Assignment+DatabaseCodable.swift
@@ -110,7 +110,7 @@ extension Assignment: DatabaseCodable {
         self.createdAt = resultSet.date(forColumn: table.createdAt.name)!
         self.subjectID = resultSet.long(forColumn: table.subjectID.name)
         self.subjectType = resultSet.rawValue(SubjectType.self, forColumn: table.subjectType.name)!
-        self.level = resultSet.long(forColumn: table.level.name)
+//        self.level = resultSet.long(forColumn: table.level.name)
         self.srsStage = resultSet.long(forColumn: table.srsStage.name)
         self.srsStageName = resultSet.string(forColumn: table.srsStageName.name)!
         self.unlockedAt = resultSet.date(forColumn: table.unlockedAt.name)

--- a/WaniKaniKit/Model/Assignment.swift
+++ b/WaniKaniKit/Model/Assignment.swift
@@ -9,7 +9,6 @@ public struct Assignment: ResourceCollectionItemData, Equatable {
     public let createdAt: Date
     public let subjectID: Int
     public let subjectType: SubjectType
-    public let level: Int
     public let srsStage: Int
     public let srsStageName: String
     public let unlockedAt: Date?
@@ -26,7 +25,6 @@ public struct Assignment: ResourceCollectionItemData, Equatable {
         case createdAt = "created_at"
         case subjectID = "subject_id"
         case subjectType = "subject_type"
-        case level
         case srsStage = "srs_stage"
         case srsStageName = "srs_stage_name"
         case unlockedAt = "unlocked_at"
@@ -42,6 +40,12 @@ public struct Assignment: ResourceCollectionItemData, Equatable {
 }
 
 public extension Assignment {
+    var level: Int {
+        print("subjectType \(subjectType)")
+        print("subjectID \(subjectID)")
+        return 1
+    }
+
     public static func isAcceleratedLevel(_ level: Int) -> Bool {
         return level <= 2
     }


### PR DESCRIPTION
Related to #18 it seems like the level value was removed from the Assignment model and moved to Subject. Assignment already has a pointer to subjectID and subjectType so ideally should be able to read from there, but there is a lot of plumbing in the app that makes it difficult to jump in and understand ^^;

I don't expect this patch to be accepted but hopefully to just document where I think part of the problem is