### PR TITLE
Add review count to notification text

### DIFF
--- a/AlliCrab/NotificationManager.swift
+++ b/AlliCrab/NotificationManager.swift
@@ -66,7 +66,7 @@ class NotificationManager {
             if let nextReviewDate = nextReviewDate, currentReviewCount == 0 {
                 let nextReviewCount = futureReviews.first!.itemCounts.total
                 if (nextReviewCount == 1) {
-                    notificationScheduler.scheduleNotification(at: nextReviewDate, body: "You have one new WaniKani review available")
+                    notificationScheduler.scheduleNotification(at: nextReviewDate, body: "You have 1 new WaniKani review available")
                 } else {
                     notificationScheduler.scheduleNotification(at: nextReviewDate, body: "You have \(nextReviewCount) new WaniKani reviews available")
                 }

--- a/AlliCrab/NotificationManager.swift
+++ b/AlliCrab/NotificationManager.swift
@@ -62,9 +62,14 @@ class NotificationManager {
             
             let futureReviews = reviewTimeline.lazy.filter({ review in review.dateAvailable > now }).prefix(48)
             let nextReviewDate = futureReviews.first?.dateAvailable
-            
+
             if let nextReviewDate = nextReviewDate, currentReviewCount == 0 {
-                notificationScheduler.scheduleNotification(at: nextReviewDate, body: "You have new WaniKani reviews available")
+                let nextReviewCount = futureReviews.first!.itemCounts.total
+                if (nextReviewCount == 1) {
+                    notificationScheduler.scheduleNotification(at: nextReviewDate, body: "You have one new WaniKani review available")
+                } else {
+                    notificationScheduler.scheduleNotification(at: nextReviewDate, body: "You have \(nextReviewCount) new WaniKani reviews available")
+                }
             }
             
             var cumulativeReviewTotal = currentReviewCount


### PR DESCRIPTION
When I'm notified of new reviews I would like to know the number of reviews waiting. This branch adds the count to the notification text. I'm running this locally but thought I would post it if it's helpful to merge.