### PR TITLE
Fix UI annoyances with review page

### DIFF
--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -6,6 +6,44 @@ function GM_addStyle(cssContents) {
     document.head.appendChild(style);
 }
 
+// Create listenable events for jquery show/hide
+$.each(['show', 'hide'], function (i, ev) {
+    var el = $.fn[ev];
+    $.fn[ev] = function () {
+        this.trigger(ev);
+        return el.apply(this, arguments);
+    };
+});
+
+var userResponseInput = $('#user-response');
+var loadingDiv = $('#loading');
+if (userResponseInput != null) {
+    if (loadingDiv != null) {
+        // Logic to prevent response input focus until the loading panel is hidden
+
+        function cancelEvent (e) {
+            userResponseInput.blur();
+            e.stopPropagation();
+            e.preventDefault();
+        }
+
+        function handleLoadingHidden () {
+            userResponseInput.off('focus', cancelEvent);
+            userResponseInput.focus();
+        };
+
+        function handleLoadingShown () {
+            userResponseInput.on('focus', cancelEvent);
+            userResponseInput.blur();
+        };
+
+        if (loadingDiv.is(":visible")) {
+            handleLoadingShown();
+        }
+        loadingDiv.on('hide', handleLoadingHidden);
+        loadingDiv.on('show', handleLoadingShown)
+    }
+}
 
 // Add close button to timeout full-screen popup
 $('#timeout').prepend('<button id="timeout-close" type="button">&times;</button>');

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -20,7 +20,6 @@ var loadingDiv = $('#loading');
 if (userResponseInput != null) {
     if (loadingDiv != null) {
         // Logic to prevent response input focus until the loading panel is hidden
-
         function cancelEvent (e) {
             userResponseInput.blur();
             e.stopPropagation();
@@ -43,6 +42,13 @@ if (userResponseInput != null) {
         loadingDiv.on('hide', handleLoadingHidden);
         loadingDiv.on('show', handleLoadingShown)
     }
+    
+    // Logic to fix scrolling issue on focus of response input
+    window.addEventListener("scroll", function (e) {
+        if (userResponseInput.is(":focus")) {
+            document.body.scrollTop = 0;
+        }
+    })
 }
 
 // Add close button to timeout full-screen popup

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -7,11 +7,11 @@ function GM_addStyle(cssContents) {
 }
 
 // Create listenable events for jquery show/hide
-$.each(['show', 'hide'], function (i, ev) {
-    var el = $.fn[ev];
-    $.fn[ev] = function () {
-        this.trigger(ev);
-        return el.apply(this, arguments);
+$.each(['show', 'hide'], function (i, eventName) {
+    var origEventFn = $.fn[eventName];
+    $.fn[eventName] = function () {
+        this.trigger(eventName);
+        return origEventFn.apply(this, arguments);
     };
 });
 
@@ -20,19 +20,19 @@ var loadingDiv = $('#loading');
 if (userResponseInput != null) {
     if (loadingDiv != null) {
         // Logic to prevent response input focus until the loading panel is hidden
-        function cancelEvent (e) {
+        function cancelFocusEvent (e) {
             userResponseInput.blur();
             e.stopPropagation();
             e.preventDefault();
         }
 
         function handleLoadingHidden () {
-            userResponseInput.off('focus', cancelEvent);
+            userResponseInput.off('focus', cancelFocusEvent);
             userResponseInput.focus();
         };
 
         function handleLoadingShown () {
-            userResponseInput.on('focus', cancelEvent);
+            userResponseInput.on('focus', cancelFocusEvent);
             userResponseInput.blur();
         };
 
@@ -46,7 +46,7 @@ if (userResponseInput != null) {
     // Logic to fix scrolling issue on focus of response input
     window.addEventListener("scroll", function (e) {
         if (userResponseInput.is(":focus")) {
-            document.body.scrollTop = 0;
+            $("html, body").scrollTop(0)
         }
     })
 }


### PR DESCRIPTION
Fixes #25 
(Sorry, the issue was submitted from my work account and not this (personal) account)

This PR fixes two issues regarding the UI of the review page.

---

### Keyboard and text cursor visible before input field is visible. 
This was because the input exists and has focus before the loading div is hidden. This can be seen by starting up a review session in a browser, pausing the debugger in the browser's dev tools before the loading div is hidden, and checking `document.activeElement`. We do not see the keyboard on mobile browsers because they prevent the ability to focus on an input element without explicit user interaction. Because the app uses inject logic that overrides this behavior in WKWebView.swift with some swizzle "magic", you see the keyboard immediately.

The solution here is to block the focus of the input while the loading panel is visible, and re-focus on the input once the loading panel is hidden.

---

### Random page scroll on input focus.
This one was weird, and I believe it is iOS trying to be helpful and scroll the page so that the field is centered in the remaining viewport when it is focused. This makes the kanji appear cut off, which doesn't help when doing reviews very much... 

I noticed in WK's core logic that they are handling this on the input's click (which is why you see that "jump" when you click on the input on both the app and in safari) but that doesn't help with the explicit calls to focus. This is from the WK unminified source code...
```javascript
if ($("#reviews").length) return kanaChart.init(), additionalContent.load(), additionalContent.itemInfoAllButton(), e.load(), e.processAnswer(), e.buttons(), e.listenSubmitFailedQueue(), e.counters(), e.listenRenderView(), e.listenWrapUp(), $("#user-response").click(function() {
    return $("html, body").scrollTop(0)
}), hotKeys.load(), idleTime.load()
```

The solution here is to listen for the scroll event on the window, and change the scroll back to the top if the input is focused. This will allow the page to still be scrolled if the info detail extends past the viewport. I'm assuming this will also resolve the issues attempted to be fixed by PR #16 