### PR TITLE
Add Script descriptions

### DIFF
--- a/AlliCrab/UserScripts/UserScripts.swift
+++ b/AlliCrab/UserScripts/UserScripts.swift
@@ -24,6 +24,7 @@ enum UserScriptInjectionRule {
 class UserScript {
     let name: String
     let author: String?
+    let updater: String?
     let description: String
     let forumLink: URL?
     let requiresFonts: Bool
@@ -43,9 +44,10 @@ class UserScript {
         }
     }
     
-    init(name: String, author: String? = nil, description: String, forumLink: URL? = nil, settingKey: ApplicationSettingKey? = nil, requiresFonts: Bool = false, stylesheetNames: [String]? = nil, scriptNames: [String]? = nil, injectionRules: [UserScriptInjectionRule]) {
+    init(name: String, author: String? = nil, updater: String? = nil, description: String, forumLink: URL? = nil, settingKey: ApplicationSettingKey? = nil, requiresFonts: Bool = false, stylesheetNames: [String]? = nil, scriptNames: [String]? = nil, injectionRules: [UserScriptInjectionRule]) {
         self.name = name
         self.author = author
+        self.updater = updater
         self.description = description
         self.forumLink = forumLink
         self.settingKey = settingKey
@@ -107,7 +109,7 @@ struct UserScriptDefinitions {
     static let community: [UserScript] = [
         UserScript(name: "Close But No Cigar",
                    author: "Ethan",
-                   description: "Prevent \"Your answer was a bit off\" answers from being accepted.  Script by Ethan.",
+                   description: "Prevent \"Your answer was a bit off\" answers from being accepted.",
                    forumLink: WaniKaniURL.forumTopic(withRelativePath: "userscript-prevent-your-answer-was-a-bit-off-answers-from-being-accepted-a-k-a-close-but-no-cigar/7134"),
                    settingKey: .userScriptCloseButNoCigarEnabled,
                    scriptNames: ["WKButNoCigar.user"],
@@ -115,7 +117,7 @@ struct UserScriptDefinitions {
         
         UserScript(name: "Jitai",
                    author: "obskyr",
-                   description: "Display WaniKani reviews in randomised fonts, for more varied reading training.  Script by obskyr.",
+                   description: "Display WaniKani reviews in randomised fonts for more varied reading training.",
                    forumLink: WaniKaniURL.forumTopic(withRelativePath: "jitai-the-font-randomizer-that-fits/12617"),
                    settingKey: .userScriptJitaiEnabled,
                    requiresFonts: true,
@@ -124,7 +126,7 @@ struct UserScriptDefinitions {
         
         UserScript(name: "WaniKani Improve",
                    author: "Seiji",
-                   description: "Automatically moves to the next item if the answer was correct (also known as \"lightning mode\").  Script by Seiji.",
+                   description: "Automatically moves to the next item if the answer was correct (also known as \"lightning mode\").",
                    forumLink: WaniKaniURL.forumTopic(withRelativePath: "wanikani-improve-2-2-2-faster-and-smarter-reviews/2858"),
                    settingKey: .userScriptWaniKaniImproveEnabled,
                    stylesheetNames: ["jquery.qtip.min"],
@@ -132,8 +134,9 @@ struct UserScriptDefinitions {
                    injectionRules: [.ExactMatch(WaniKaniURL.reviewSession)]),
         
         UserScript(name: "WaniKani Override",
-                   author: "ruipgpinheiro, Mempo",
-                   description: "Adds an \"Ignore Answer\" button to the bottom of WaniKani review pages, permitting incorrect answers to be ignored.  This script is intended to be used to correct genuine mistakes, like typographical errors.  Script by ruipgpinheiro, updated by Mempo.",
+                   author: "ruipgpinheiro",
+                   updater: "Mempo",
+                   description: "Adds an \"Ignore Answer\" button to the bottom of WaniKani review pages, permitting incorrect answers to be ignored.  This script is intended to be used to correct genuine mistakes, like typographical errors.",
                    forumLink: WaniKaniURL.forumTopic(withRelativePath: "userscript-wanikani-override-ignore-answer-button-active-support/17999"),
                    settingKey: .userScriptIgnoreAnswerEnabled,
                    scriptNames: ["wkoverride.user"],

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -40,13 +40,13 @@ if (userResponseInput != null) {
             handleLoadingShown();
         }
         loadingDiv.on('hide', handleLoadingHidden);
-        loadingDiv.on('show', handleLoadingShown)
+        loadingDiv.on('show', handleLoadingShown);
     }
     
     // Logic to fix scrolling issue on focus of response input
     window.addEventListener("scroll", function (e) {
         if (userResponseInput.is(":focus")) {
-            $("html, body").scrollTop(0)
+            $("html, body").scrollTop(0);
         }
     })
 }

--- a/AlliCrab/ViewControllers/SettingsTableViewController.swift
+++ b/AlliCrab/ViewControllers/SettingsTableViewController.swift
@@ -137,12 +137,16 @@ class SettingsTableViewController: UITableViewController {
         
         switch tableViewSection {
         case let .userScript(userScript):
-            guard let author = userScript.author else {
-                return nil
+            var scriptFooter = userScript.description
+            if userScript.author != nil {
+                scriptFooter += " Created by \(userScript.author!)."
             }
-            return "Script by \(author)"
+            if userScript.updater != nil {
+                scriptFooter += " Updated by \(userScript.updater!)."
+            }
+            return scriptFooter
         case .feedback:
-            return "Please check the app forum topic for the latest news and support"
+            return "Please check the app forum topic for the latest news and support."
         case .logOut:
             let (product, version, build) = self.productAndVersion
             return "\(product) version \(version) (build \(build))"

--- a/AlliCrab/ViewControllers/SettingsTableViewController.swift
+++ b/AlliCrab/ViewControllers/SettingsTableViewController.swift
@@ -138,11 +138,11 @@ class SettingsTableViewController: UITableViewController {
         switch tableViewSection {
         case let .userScript(userScript):
             var scriptFooter = userScript.description
-            if userScript.author != nil {
-                scriptFooter += " Created by \(userScript.author!)."
+            if let author = userScript.author {
+                scriptFooter += " Created by \(author)."
             }
-            if userScript.updater != nil {
-                scriptFooter += " Updated by \(userScript.updater!)."
+            if let updater = userScript.updater {
+                scriptFooter += " Updated by \(updater)."
             }
             return scriptFooter
         case .feedback:


### PR DESCRIPTION
This adds the script descriptions back into the footer of the user script table view. The duplicate "created by, updated by" strings were removed from the description and are appended conditionally so that it will be easier to add/remove info into the footer string if needed.

Also adds some missing semicolons in the JS from my last PR because it was bothering me. It would still run the same without them.

Fixes #28 