### PR TITLE
Dynamically shrink long vocab text to fit in one line

### DIFF
--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -158,7 +158,7 @@ if (textNode.length > 0) {
         while (isReview ? textNode.width() > boundingWidth : textNode.prop('scrollWidth') > boundingWidth) {
             // The text is extended beyond the available width of the container...
             var currentFontSize = parseInt(textNode.css("font-size"), 10);
-            if (currentFontSize <= 0) {
+            if (currentFontSize - 5 <= 0) {
                 // This should NEVER happen, but is here just to prevent all possibility of an infinite loop.
                 textNode.css("font-size", "");
                 return;

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -145,8 +145,6 @@ if (!String.prototype.repeat) {
 }
 
 // Logic to handle resizing long text to fit within one line
-//#reviews #question #character,
-//#lessons header #main-info #character {
 var textNode = $('#reviews #question #character span');
 var isReview = textNode.length > 0;
 if (!isReview) {
@@ -154,7 +152,7 @@ if (!isReview) {
 }
 if (textNode.length > 0) {
     var observer = new MutationObserver(function() {
-        // The review span value changed
+        // The review span value changed. Reset the font-size to the default inherited value and resize if needed
         textNode.css("font-size", "");
         var boundingWidth = isReview ? textNode.parent().width() : textNode.outerWidth();
         while (isReview ? textNode.width() > boundingWidth : textNode.prop('scrollWidth') > boundingWidth) {
@@ -167,7 +165,7 @@ if (textNode.length > 0) {
                 return;
             }
             
-            // Shrink the font size by 5px and re-test
+            // Shrink the font size by 5px and re-test (NOTE: cannot use jQuery ".css" because it doesn't support "important")
             textNode[0].style.setProperty('font-size', (currentFontSize - 5)  + 'px', 'important');
         }
     });

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -157,8 +157,8 @@ if (textNode.length > 0) {
         var boundingWidth = isReview ? textNode.parent().width() : textNode.outerWidth();
         while (isReview ? textNode.width() > boundingWidth : textNode.prop('scrollWidth') > boundingWidth) {
             // The text is extended beyond the available width of the container...
-            var currentFontSize = parseInt(textNode.css("font-size"), 10);
-            if (currentFontSize - 5 <= 0) {
+            var smallerFontSize = parseInt(textNode.css("font-size"), 10) - 5;
+            if (smallerFontSize <= 0) {
                 // This should NEVER happen, but is here just to prevent all possibility of an infinite loop.
                 textNode.css("font-size", "");
                 return;
@@ -166,7 +166,7 @@ if (textNode.length > 0) {
             
             // Shrink the font size by 5px and re-test 
             // NOTE: We cannot use jQuery ".css" to set the font here because it doesn't support "important"
-            textNode[0].style.setProperty('font-size', (currentFontSize - 5)  + 'px', 'important');
+            textNode[0].style.setProperty('font-size', smallerFontSize  + 'px', 'important');
         }
     });
 

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -145,29 +145,36 @@ if (!String.prototype.repeat) {
 }
 
 // Logic to handle resizing long text to fit within one line
-var reviewSpan = $('#character span');
-var reviewSpanContainer = $('#character');
-if (reviewSpanContainer.length && reviewSpan.length) {
+var container = $('#main-info');
+var textNode = null;
+var isReview = !container.length;
+if (isReview) {
+    container = $('#character');
+    textNode = $('#character span');
+}
+else {
+    textNode = $('#character');
+}
+if (container.length && textNode.length) {
     var observer = new MutationObserver(function() {
         // The review span value changed
-        // Reset the font-size to the default size defined by the css class
-        reviewSpan.css("font-size", "");
-        
-        while (reviewSpan.outerWidth() >= reviewSpanContainer.width()) {
+        textNode.css("font-size", "");
+        var containerWidth = isReview ? container.width() : textNode.outerWidth();
+        while (isReview ? textNode.width() > containerWidth : textNode.prop('scrollWidth') > containerWidth) {
             // The text is extended beyond the available width of the container
-            var currentFontSize = parseInt(reviewSpan.css("font-size"), 10);
+            var currentFontSize = parseInt(textNode.css("font-size"), 10);
             
             if (currentFontSize <= 0) {
                 // This should NEVER happen, but is here just to prevent all possibility of an infinite loop.
-                reviewSpan.css("font-size", "");
+                textNode.css("font-size", "");
                 return;
             }
             
             // Shrink the font size by 5px and re-test
-            reviewSpan.css("font-size", currentFontSize - 5);
+            textNode[0].style.setProperty('font-size', (currentFontSize - 5)  + 'px', 'important');
         }
     });
 
     // Start observing the review span for changes
-    observer.observe(reviewSpan[0], {childList: true});
+    observer.observe(textNode[0], {childList: true, subtree: !isReview});
 }

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -145,22 +145,19 @@ if (!String.prototype.repeat) {
 }
 
 // Logic to handle resizing long text to fit within one line
-var container = $('#main-info');
-var textNode = null;
-var isReview = !container.length;
-if (isReview) {
-    container = $('#character');
-    textNode = $('#character span');
+//#reviews #question #character,
+//#lessons header #main-info #character {
+var textNode = $('#reviews #question #character span');
+var isReview = textNode.length > 0;
+if (!isReview) {
+    textNode = $('#lessons header #main-info #character');
 }
-else {
-    textNode = $('#character');
-}
-if (container.length && textNode.length) {
+if (textNode.length > 0) {
     var observer = new MutationObserver(function() {
         // The review span value changed
         textNode.css("font-size", "");
-        var containerWidth = isReview ? container.width() : textNode.outerWidth();
-        while (isReview ? textNode.width() > containerWidth : textNode.prop('scrollWidth') > containerWidth) {
+        var boundingWidth = isReview ? textNode.parent().width() : textNode.outerWidth();
+        while (isReview ? textNode.width() > boundingWidth : textNode.prop('scrollWidth') > boundingWidth) {
             // The text is extended beyond the available width of the container
             var currentFontSize = parseInt(textNode.css("font-size"), 10);
             

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -143,3 +143,31 @@ if (!String.prototype.repeat) {
         return rpt;
     }
 }
+
+// Logic to handle resizing long text to fit within one line
+var reviewSpan = $('#character span');
+var reviewSpanContainer = $('#character');
+if (reviewSpanContainer.length && reviewSpan.length) {
+    var observer = new MutationObserver(function() {
+        // The review span value changed
+        // Reset the font-size to the default size defined by the css class
+        reviewSpan.css("font-size", "");
+        
+        while (reviewSpan.outerWidth() >= reviewSpanContainer.width()) {
+            // The text is extended beyond the available width of the container
+            var currentFontSize = parseInt(reviewSpan.css("font-size"), 10);
+            
+            if (currentFontSize <= 0) {
+                // This should NEVER happen, but is here just to prevent all possibility of an infinite loop.
+                reviewSpan.css("font-size", "");
+                return;
+            }
+            
+            // Shrink the font size by 5px and re-test
+            reviewSpan.css("font-size", currentFontSize - 5);
+        }
+    });
+
+    // Start observing the review span for changes
+    observer.observe(reviewSpan[0], {childList: true});
+}

--- a/AlliCrab/UserScripts/common.js
+++ b/AlliCrab/UserScripts/common.js
@@ -152,24 +152,24 @@ if (!isReview) {
 }
 if (textNode.length > 0) {
     var observer = new MutationObserver(function() {
-        // The review span value changed. Reset the font-size to the default inherited value and resize if needed
+        // The lesson/review item has changed. Reset the font-size to the default inherited value and resize if needed
         textNode.css("font-size", "");
         var boundingWidth = isReview ? textNode.parent().width() : textNode.outerWidth();
         while (isReview ? textNode.width() > boundingWidth : textNode.prop('scrollWidth') > boundingWidth) {
-            // The text is extended beyond the available width of the container
+            // The text is extended beyond the available width of the container...
             var currentFontSize = parseInt(textNode.css("font-size"), 10);
-            
             if (currentFontSize <= 0) {
                 // This should NEVER happen, but is here just to prevent all possibility of an infinite loop.
                 textNode.css("font-size", "");
                 return;
             }
             
-            // Shrink the font size by 5px and re-test (NOTE: cannot use jQuery ".css" because it doesn't support "important")
+            // Shrink the font size by 5px and re-test 
+            // NOTE: We cannot use jQuery ".css" to set the font here because it doesn't support "important"
             textNode[0].style.setProperty('font-size', (currentFontSize - 5)  + 'px', 'important');
         }
     });
 
-    // Start observing the review span for changes
+    // Start observing the lesson/review item text for changes
     observer.observe(textNode[0], {childList: true, subtree: !isReview});
 }

--- a/AlliCrab/UserScripts/resize.css
+++ b/AlliCrab/UserScripts/resize.css
@@ -21,7 +21,8 @@ header #main-info #character {
     vertical-align: middle;
 }
 
-#reviews #question #character {
+#reviews #question #character,
+#lessons header #main-info #character {
     white-space: nowrap;
     padding-left: 4vw !important;
     padding-right: 4vw !important;

--- a/AlliCrab/UserScripts/resize.css
+++ b/AlliCrab/UserScripts/resize.css
@@ -21,6 +21,12 @@ header #main-info #character {
     vertical-align: middle;
 }
 
+#reviews #question #character {
+    white-space: nowrap;
+    padding-left: 4vw !important;
+    padding-right: 4vw !important;
+}
+
 @media (min-width: 320px) and (max-width: 767px) {
     #reviews #question #character, #lessons header #main-info #character {
         font-size: 10vh !important; line-height: 20vh !important; padding: 10px 0 0;


### PR DESCRIPTION
Fixes #35

This PR implements a listener on change of the review and lesson page's text value, and reset the font size then shrink the font-size by 5px until it fits if needed. It's a bit hacky, but it works. 

Side note: WK puts the text in a span inside the #character div for reviews, but puts the text directly as the innerText of the #character div for lessons which is less than ideal... 😑