### PR TITLE
Persist review timeline settings

### DIFF
--- a/AlliCrab/ApplicationSettings.swift
+++ b/AlliCrab/ApplicationSettings.swift
@@ -96,18 +96,20 @@ struct ApplicationSettings {
     static var reviewTimelineFilterType: ReviewTimelineFilter? {
         get { return ReviewTimelineFilter(rawValue: userDefaults.integer(forKey: .reviewTimelineFilterType)) }
         set {
-            if let timelineFilterValue = newValue {
-                userDefaults.set(timelineFilterValue.rawValue, forKey: .reviewTimelineFilterType)
+            guard let timelineFilterValue = newValue else {
+                return
             }
+            userDefaults.set(timelineFilterValue.rawValue, forKey: .reviewTimelineFilterType)
         }
     }
     
     static var reviewTimelineValueType: ReviewTimelineCountMethod? {
         get { return ReviewTimelineCountMethod(rawValue: userDefaults.integer(forKey: .reviewTimelineValueType))}
         set {
-            if let timelineCountMethod = newValue {
-                userDefaults.set(timelineCountMethod.rawValue, forKey: .reviewTimelineValueType)
+            guard let timelineCountMethod = newValue else {
+                return
             }
+            userDefaults.set(timelineCountMethod.rawValue, forKey: .reviewTimelineValueType)
         }
     }
     
@@ -168,7 +170,7 @@ extension UserDefaults {
     func bool(forKey defaultName: ApplicationSettingKey) -> Bool {
         return bool(forKey: defaultName.rawValue)
     }
-    
+
     func integer(forKey defaultName: ApplicationSettingKey) -> Int {
         return integer(forKey: defaultName.rawValue)
     }

--- a/AlliCrab/ApplicationSettings.swift
+++ b/AlliCrab/ApplicationSettings.swift
@@ -19,6 +19,8 @@ enum ApplicationSettingKey: String {
     case userScriptDoubleCheckEnabled = "userScript-DoubleCheck"
     case userScriptWaniKaniImproveEnabled = "userScript-WaniKaniImprove"
     case userScriptReorderUltimateEnabled = "userScript-ReorderUltimate"
+    case reviewTimelineFilterType = "reviewTimelineFilterType"
+    case reviewTimelineValueType = "reviewTimelineValueType"
 }
 
 extension UIColor {
@@ -91,6 +93,24 @@ struct ApplicationSettings {
         set { userDefaults.set(newValue, forKey: .userScriptReorderUltimateEnabled) }
     }
     
+    static var reviewTimelineFilterType: ReviewTimelineFilter? {
+        get { return ReviewTimelineFilter(rawValue: userDefaults.integer(forKey: .reviewTimelineFilterType)) }
+        set {
+            if let timelineFilterValue = newValue {
+                userDefaults.set(timelineFilterValue.rawValue, forKey: .reviewTimelineFilterType)
+            }
+        }
+    }
+    
+    static var reviewTimelineValueType: ReviewTimelineCountMethod? {
+        get { return ReviewTimelineCountMethod(rawValue: userDefaults.integer(forKey: .reviewTimelineValueType))}
+        set {
+            if let timelineCountMethod = newValue {
+                userDefaults.set(timelineCountMethod.rawValue, forKey: .reviewTimelineValueType)
+            }
+        }
+    }
+    
     static func resetToDefaults() {
         apiKey = nil
         notificationStrategy = .firstReviewSession
@@ -103,6 +123,8 @@ struct ApplicationSettings {
         userScriptDoubleCheckEnabled = false
         userScriptWaniKaniImproveEnabled = false
         userScriptReorderUltimateEnabled = false
+        reviewTimelineFilterType = ReviewTimelineFilter.none
+        reviewTimelineValueType = ReviewTimelineCountMethod.histogram
     }
 }
 
@@ -145,6 +167,10 @@ extension UserDefaults {
     
     func bool(forKey defaultName: ApplicationSettingKey) -> Bool {
         return bool(forKey: defaultName.rawValue)
+    }
+    
+    func integer(forKey defaultName: ApplicationSettingKey) -> Int {
+        return integer(forKey: defaultName.rawValue)
     }
     
     func rawValue<T: RawRepresentable>(_ type: T.Type, forKey defaultName: ApplicationSettingKey) -> T? {

--- a/AlliCrab/ApplicationSettings.swift
+++ b/AlliCrab/ApplicationSettings.swift
@@ -93,24 +93,14 @@ struct ApplicationSettings {
         set { userDefaults.set(newValue, forKey: .userScriptReorderUltimateEnabled) }
     }
     
-    static var reviewTimelineFilterType: ReviewTimelineFilter? {
-        get { return ReviewTimelineFilter(rawValue: userDefaults.integer(forKey: .reviewTimelineFilterType)) }
-        set {
-            guard let timelineFilterValue = newValue else {
-                return
-            }
-            userDefaults.set(timelineFilterValue.rawValue, forKey: .reviewTimelineFilterType)
-        }
+    static var reviewTimelineFilterType: ReviewTimelineFilter {
+        get { return userDefaults.rawValue(ReviewTimelineFilter.self, forKey: .reviewTimelineFilterType) ?? .none }
+        set { userDefaults.set(newValue, forKey: .reviewTimelineFilterType) }
     }
     
-    static var reviewTimelineValueType: ReviewTimelineCountMethod? {
-        get { return ReviewTimelineCountMethod(rawValue: userDefaults.integer(forKey: .reviewTimelineValueType))}
-        set {
-            guard let timelineCountMethod = newValue else {
-                return
-            }
-            userDefaults.set(timelineCountMethod.rawValue, forKey: .reviewTimelineValueType)
-        }
+    static var reviewTimelineValueType: ReviewTimelineCountMethod {
+        get { return userDefaults.rawValue(ReviewTimelineCountMethod.self, forKey: .reviewTimelineValueType) ?? .histogram }
+        set { userDefaults.set(newValue, forKey: .reviewTimelineValueType) }
     }
     
     static func resetToDefaults() {
@@ -125,8 +115,8 @@ struct ApplicationSettings {
         userScriptDoubleCheckEnabled = false
         userScriptWaniKaniImproveEnabled = false
         userScriptReorderUltimateEnabled = false
-        reviewTimelineFilterType = ReviewTimelineFilter.none
-        reviewTimelineValueType = ReviewTimelineCountMethod.histogram
+        reviewTimelineFilterType = .none
+        reviewTimelineValueType = .histogram
     }
 }
 
@@ -169,10 +159,6 @@ extension UserDefaults {
     
     func bool(forKey defaultName: ApplicationSettingKey) -> Bool {
         return bool(forKey: defaultName.rawValue)
-    }
-
-    func integer(forKey defaultName: ApplicationSettingKey) -> Int {
-        return integer(forKey: defaultName.rawValue)
     }
     
     func rawValue<T: RawRepresentable>(_ type: T.Type, forKey defaultName: ApplicationSettingKey) -> T? {

--- a/AlliCrab/ViewControllers/ReviewTimelineOptionsTableViewController.swift
+++ b/AlliCrab/ViewControllers/ReviewTimelineOptionsTableViewController.swift
@@ -124,9 +124,11 @@ class ReviewTimelineOptionsTableViewController: UITableViewController {
         case .filter:
             previousSelection = selectedFilterValue.map { IndexPath(row: filterValues.firstIndex(of: $0)!, section: indexPath.section) }
             selectedFilterValue = filterValues[indexPath.row]
+            ApplicationSettings.reviewTimelineFilterType = selectedFilterValue
         case .countMethod:
             previousSelection = selectedCountMethodValue.map { IndexPath(row: countMethodValues.firstIndex(of: $0)!, section: indexPath.section) }
             selectedCountMethodValue = countMethodValues[indexPath.row]
+            ApplicationSettings.reviewTimelineValueType = selectedCountMethodValue
         }
         
         if let previousSelection = previousSelection {

--- a/AlliCrab/ViewControllers/ReviewTimelineOptionsTableViewController.swift
+++ b/AlliCrab/ViewControllers/ReviewTimelineOptionsTableViewController.swift
@@ -26,21 +26,8 @@ class ReviewTimelineOptionsTableViewController: UITableViewController {
     
     weak var delegate: ReviewTimelineOptionsDelegate?
     
-    var selectedFilterValue: ReviewTimelineFilter? {
-        didSet {
-            if let selectedValue = selectedFilterValue {
-                delegate?.reviewTimelineFilter(didChangeTo: selectedValue)
-            }
-        }
-    }
-    
-    var selectedCountMethodValue: ReviewTimelineCountMethod? {
-        didSet {
-            if let selectedValue = selectedCountMethodValue {
-                delegate?.reviewTimelineCountMethod(didChangeTo: selectedValue)
-            }
-        }
-    }
+    var selectedFilterValue: ReviewTimelineFilter = ApplicationSettings.reviewTimelineFilterType
+    var selectedCountMethodValue: ReviewTimelineCountMethod = ApplicationSettings.reviewTimelineValueType
     
     private let filterValues = ReviewTimelineFilter.allCases
     private let countMethodValues = ReviewTimelineCountMethod.allCases
@@ -122,13 +109,19 @@ class ReviewTimelineOptionsTableViewController: UITableViewController {
         let previousSelection: IndexPath?
         switch tableViewSection {
         case .filter:
-            previousSelection = selectedFilterValue.map { IndexPath(row: filterValues.firstIndex(of: $0)!, section: indexPath.section) }
+            previousSelection = IndexPath(row: ReviewTimelineFilter.allCases.firstIndex(of: ApplicationSettings.reviewTimelineFilterType)!, section: indexPath.section)
             selectedFilterValue = filterValues[indexPath.row]
-            ApplicationSettings.reviewTimelineFilterType = selectedFilterValue
+            if ApplicationSettings.reviewTimelineFilterType != selectedFilterValue {
+                ApplicationSettings.reviewTimelineFilterType = selectedFilterValue
+                delegate?.reviewTimelineFilter(didChangeTo: selectedFilterValue)
+            }
         case .countMethod:
-            previousSelection = selectedCountMethodValue.map { IndexPath(row: countMethodValues.firstIndex(of: $0)!, section: indexPath.section) }
+            previousSelection = IndexPath(row: ReviewTimelineCountMethod.allCases.firstIndex(of: ApplicationSettings.reviewTimelineValueType)!, section: indexPath.section)
             selectedCountMethodValue = countMethodValues[indexPath.row]
-            ApplicationSettings.reviewTimelineValueType = selectedCountMethodValue
+            if ApplicationSettings.reviewTimelineValueType != selectedCountMethodValue {
+                ApplicationSettings.reviewTimelineValueType = selectedCountMethodValue
+                delegate?.reviewTimelineCountMethod(didChangeTo: selectedCountMethodValue)
+            }
         }
         
         if let previousSelection = previousSelection {

--- a/AlliCrab/ViewControllers/ReviewTimelineTableViewController.swift
+++ b/AlliCrab/ViewControllers/ReviewTimelineTableViewController.swift
@@ -9,12 +9,15 @@ import os
 import UIKit
 import WaniKaniKit
 
-enum ReviewTimelineFilter: CaseIterable {
-    case none, currentLevel, toBeBurned
+enum ReviewTimelineFilter: Int, CaseIterable {
+    case none = 0
+    case currentLevel = 1
+    case toBeBurned = 2
 }
 
-enum ReviewTimelineCountMethod: CaseIterable {
-    case histogram, cumulative
+enum ReviewTimelineCountMethod: Int, CaseIterable {
+    case histogram = 0
+    case cumulative = 1
 }
 
 class ReviewTimelineTableViewController: UITableViewController {
@@ -37,13 +40,13 @@ class ReviewTimelineTableViewController: UITableViewController {
         }
     }
     
-    private var filter: ReviewTimelineFilter = .none {
+    private var filter: ReviewTimelineFilter = ApplicationSettings.reviewTimelineFilterType ?? .none {
         didSet {
             try! updateReviewTimeline()
         }
     }
     
-    private var countMethod: ReviewTimelineCountMethod = .histogram {
+    private var countMethod: ReviewTimelineCountMethod = ApplicationSettings.reviewTimelineValueType ?? .histogram {
         didSet {
             tableView.reloadData()
         }

--- a/AlliCrab/ViewControllers/ReviewTimelineTableViewController.swift
+++ b/AlliCrab/ViewControllers/ReviewTimelineTableViewController.swift
@@ -9,15 +9,15 @@ import os
 import UIKit
 import WaniKaniKit
 
-enum ReviewTimelineFilter: Int, CaseIterable {
-    case none = 0
-    case currentLevel = 1
-    case toBeBurned = 2
+enum ReviewTimelineFilter: String, CaseIterable {
+    case none
+    case currentLevel
+    case toBeBurned
 }
 
-enum ReviewTimelineCountMethod: Int, CaseIterable {
-    case histogram = 0
-    case cumulative = 1
+enum ReviewTimelineCountMethod: String, CaseIterable {
+    case histogram
+    case cumulative
 }
 
 class ReviewTimelineTableViewController: UITableViewController {
@@ -40,15 +40,17 @@ class ReviewTimelineTableViewController: UITableViewController {
         }
     }
     
-    private var filter: ReviewTimelineFilter = ApplicationSettings.reviewTimelineFilterType ?? .none {
+    private var filter: ReviewTimelineFilter = ApplicationSettings.reviewTimelineFilterType {
         didSet {
             try! updateReviewTimeline()
+            self.updateTitle()
         }
     }
     
-    private var countMethod: ReviewTimelineCountMethod = ApplicationSettings.reviewTimelineValueType ?? .histogram {
+    private var countMethod: ReviewTimelineCountMethod = ApplicationSettings.reviewTimelineValueType {
         didSet {
             tableView.reloadData()
+            self.updateTitle()
         }
     }
     
@@ -137,6 +139,8 @@ class ReviewTimelineTableViewController: UITableViewController {
         tableView.register(ReviewTimelineHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: ReuseIdentifier.dateHeader.rawValue)
         
         notificationObservers = addNotificationObservers()
+        
+        self.updateTitle()
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -257,6 +261,16 @@ class ReviewTimelineTableViewController: UITableViewController {
         countsForKey = [SRSReviewCounts(dateAvailable: date, itemCounts: itemCounts)]
     }
     
+    private func updateTitle() {
+        switch ApplicationSettings.reviewTimelineFilterType {
+            case .currentLevel:
+                self.navigationItem.title = "Current Level Reviews"
+            case .toBeBurned:
+                self.navigationItem.title = "Burn Reviews"
+            default:
+                self.navigationItem.title = "All Reviews"
+        }
+    }
 }
 
 extension ReviewTimelineTableViewController: ReviewTimelineOptionsDelegate {


### PR DESCRIPTION
Fixes #26 

This PR stores/retrieves the review timeline filter and count settings to/from the userDefaults. The settings are stored as integers.

Side note: I feel like there should be some indication of the current filter/count settings from the review timeline view... But I don't know what the iOS UI standard is for displaying filter info. Like a `"Showing \(countMethod) of \(filterMethod)"` ex: "Showing cumulative totals of Burn item reviews" label at the top or something?