### PR TITLE
Add specific SRS review levels userscript

### DIFF
--- a/AlliCrab.xcodeproj/project.pbxproj
+++ b/AlliCrab.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		83FEF4401F4F969900A7029D /* ReviewTimelineEntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FEF43F1F4F969900A7029D /* ReviewTimelineEntryTableViewCell.swift */; };
 		83FEF4461F50518E00A7029D /* ReviewTimelineOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FEF4451F50518E00A7029D /* ReviewTimelineOptionsTableViewController.swift */; };
 		83FFD90B1F5387B80015988F /* ReviewTimelineHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FFD90A1F5387B80015988F /* ReviewTimelineHeaderFooterView.swift */; };
+		935C5EA322FD03AF00B28C1A /* srsReviewLevels.js in Resources */ = {isa = PBXBuildFile; fileRef = 935C5EA222FD03AF00B28C1A /* srsReviewLevels.js */; };
+		935C5EA522FD133F00B28C1A /* srsReviewLevels.css in Resources */ = {isa = PBXBuildFile; fileRef = 935C5EA422FD133F00B28C1A /* srsReviewLevels.css */; };
 		9F41C9076D950FB1F5D5FAE4 /* Pods_WaniKaniKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A22927479B44A413664183A1 /* Pods_WaniKaniKitTests.framework */; };
 		B93D08FFDF5DAF0EF3DA2989 /* Pods_WaniKaniStudyQueueWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 255106F1009FFFAC9EAB809E /* Pods_WaniKaniStudyQueueWidget.framework */; };
 /* End PBXBuildFile section */
@@ -503,6 +505,8 @@
 		83FEF4451F50518E00A7029D /* ReviewTimelineOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTimelineOptionsTableViewController.swift; sourceTree = "<group>"; };
 		83FFD90A1F5387B80015988F /* ReviewTimelineHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTimelineHeaderFooterView.swift; sourceTree = "<group>"; };
 		906ABAC46CC97C2A8D68969D /* Pods-AlliCrab.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AlliCrab.release.xcconfig"; path = "Pods/Target Support Files/Pods-AlliCrab/Pods-AlliCrab.release.xcconfig"; sourceTree = "<group>"; };
+		935C5EA222FD03AF00B28C1A /* srsReviewLevels.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = srsReviewLevels.js; sourceTree = "<group>"; };
+		935C5EA422FD133F00B28C1A /* srsReviewLevels.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = srsReviewLevels.css; sourceTree = "<group>"; };
 		A22927479B44A413664183A1 /* Pods_WaniKaniKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WaniKaniKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A73A0BB811452A40B140EEF7 /* Pods-WaniKaniKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WaniKaniKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-WaniKaniKit/Pods-WaniKaniKit.release.xcconfig"; sourceTree = "<group>"; };
 		AB341FCDE560DD1E5A54810E /* Pods-WaniKaniKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WaniKaniKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WaniKaniKit/Pods-WaniKaniKit.debug.xcconfig"; sourceTree = "<group>"; };
@@ -642,6 +646,8 @@
 				832C184E1F4501EC001FFACD /* wkoverride.user.js */,
 				832C18491F4501EC001FFACD /* UserScripts.swift */,
 				832C184A1F4501EC001FFACD /* UserScriptSupport.swift */,
+				935C5EA222FD03AF00B28C1A /* srsReviewLevels.js */,
+				935C5EA422FD133F00B28C1A /* srsReviewLevels.css */,
 			);
 			path = UserScripts;
 			sourceTree = "<group>";
@@ -1234,6 +1240,7 @@
 				832C186A1F4502A4001FFACD /* chigfont.ttf in Resources */,
 				8377948122313F8A009D7D7B /* ContextSentenceView.xib in Resources */,
 				832C18721F4502A4001FFACD /* santyoume.otf in Resources */,
+				935C5EA322FD03AF00B28C1A /* srsReviewLevels.js in Resources */,
 				8364CB6B1F27F28D002DBE6B /* LaunchScreen.storyboard in Resources */,
 				8303F8301F54678400E016E9 /* ReorderSettings.storyboard in Resources */,
 				832C18701F4502A4001FFACD /* n_chifont+.ttf in Resources */,
@@ -1253,6 +1260,7 @@
 				832C184F1F4501ED001FFACD /* common.css in Resources */,
 				832C18521F4501ED001FFACD /* jitai.user.js in Resources */,
 				8377C69322308BAE00656E9A /* SubjectDetail.storyboard in Resources */,
+				935C5EA522FD133F00B28C1A /* srsReviewLevels.css in Resources */,
 				832C18561F4501ED001FFACD /* noswipe.js in Resources */,
 				832C186E1F4502A4001FFACD /* hkgokukaikk.ttf in Resources */,
 			);

--- a/AlliCrab/ApplicationSettings.swift
+++ b/AlliCrab/ApplicationSettings.swift
@@ -16,6 +16,7 @@ enum ApplicationSettingKey: String {
     case userScriptCloseButNoCigarEnabled = "userScript-CloseButNoCigar"
     case userScriptJitaiEnabled = "userScript-Jitai"
     case userScriptIgnoreAnswerEnabled = "userScript-IgnoreAnswer"
+    case userScriptShowSRSReviewLevel = "userScript-ShowSRSLevel"
     case userScriptDoubleCheckEnabled = "userScript-DoubleCheck"
     case userScriptWaniKaniImproveEnabled = "userScript-WaniKaniImprove"
     case userScriptReorderUltimateEnabled = "userScript-ReorderUltimate"
@@ -78,6 +79,11 @@ struct ApplicationSettings {
         set { userDefaults.set(newValue, forKey: .userScriptIgnoreAnswerEnabled) }
     }
     
+    static var userScriptShowSRSReviewLevel: Bool {
+        get { return userDefaults.bool(forKey: .userScriptShowSRSReviewLevel) }
+        set { userDefaults.set(newValue, forKey: .userScriptShowSRSReviewLevel) }
+    }
+    
     static var userScriptDoubleCheckEnabled: Bool {
         get { return userDefaults.bool(forKey: .userScriptDoubleCheckEnabled) }
         set { userDefaults.set(newValue, forKey: .userScriptDoubleCheckEnabled) }
@@ -112,6 +118,7 @@ struct ApplicationSettings {
         userScriptCloseButNoCigarEnabled = false
         userScriptJitaiEnabled = false
         userScriptIgnoreAnswerEnabled = false
+        userScriptShowSRSReviewLevel = false
         userScriptDoubleCheckEnabled = false
         userScriptWaniKaniImproveEnabled = false
         userScriptReorderUltimateEnabled = false

--- a/AlliCrab/UserScripts/UserScripts.swift
+++ b/AlliCrab/UserScripts/UserScripts.swift
@@ -141,6 +141,15 @@ struct UserScriptDefinitions {
                    settingKey: .userScriptIgnoreAnswerEnabled,
                    scriptNames: ["wkoverride.user"],
                    injectionRules: [.ExactMatch(WaniKaniURL.reviewSession)]),
+        
+        UserScript(name: "Show Specific SRS Level in Reviews",
+                   author: "seanblue",
+                   description: "Show \"Apprentice 3\" instead of \"Apprentice\", etc.",
+                   forumLink: WaniKaniURL.forumTopic(withRelativePath: "userscript-wanikani-show-specific-srs-level-in-reviews/19777"),
+                   settingKey: .userScriptShowSRSReviewLevel,
+                   stylesheetNames: ["srsReviewLevels"],
+                   scriptNames: ["srsReviewLevels"],
+                   injectionRules: [.ExactMatch(WaniKaniURL.reviewSession)]),
     ]
     
     static let all = alwaysEnabled + custom + community

--- a/AlliCrab/UserScripts/srsReviewLevels.css
+++ b/AlliCrab/UserScripts/srsReviewLevels.css
@@ -1,0 +1,23 @@
+.srs .srs-up.srs-apprentice1:after,.srs .srs-down.srs-apprentice1:after {
+    content: 'Apprentice 1'
+}
+
+.srs .srs-up.srs-apprentice2:after,.srs .srs-down.srs-apprentice2:after {
+    content: 'Apprentice 2'
+}
+
+.srs .srs-up.srs-apprentice3:after,.srs .srs-down.srs-apprentice3:after {
+    content: 'Apprentice 3'
+}
+
+.srs .srs-up.srs-apprentice4:after,.srs .srs-down.srs-apprentice4:after {
+    content: 'Apprentice 4'
+}
+
+.srs .srs-up.srs-guru1:after,.srs .srs-down.srs-guru1:after {
+    content: 'Guru 1'
+}
+
+.srs .srs-up.srs-guru2:after,.srs .srs-down.srs-guru2:after {
+    content: 'Guru 2'
+}

--- a/AlliCrab/UserScripts/srsReviewLevels.js
+++ b/AlliCrab/UserScripts/srsReviewLevels.js
@@ -1,0 +1,50 @@
+// ==UserScript==
+// @name          WaniKani Show Specific SRS Level in Reviews
+// @namespace     https://www.wanikani.com
+// @description   Show "Apprentice 3" instead of "Apprentice", etc.
+// @author        seanblue
+// @version       1.0.1
+// @include       *://www.wanikani.com/review/session*
+// @grant         none
+// ==/UserScript==
+
+const eventPrefix = 'seanblue.show_specific_srs.';
+
+// Catch additional events.
+// http://viralpatel.net/blogs/jquery-trigger-custom-event-show-hide-element/
+(function($) {$.each(['hide'], function(i, ev) { var el = $.fn[ev]; $.fn[ev] = function() { this.trigger(eventPrefix + ev); return el.apply(this, arguments); }; }); })(jQuery);
+
+(function() {
+    'use strict';
+
+    function updateSrsNames() {
+        window.Srs.name = function(e) {
+            switch (e) {
+                case 1:
+                    return "apprentice1";
+                case 2:
+                    return "apprentice2";
+                case 3:
+                    return "apprentice3";
+                case 4:
+                    return "apprentice4";
+                case 5:
+                    return "guru1";
+                case 6:
+                    return "guru2";
+                case 7:
+                    return "master";
+                case 8:
+                    return "enlighten";
+                case 9:
+                    return "burn";
+            }
+        };
+    }
+
+    (function() {
+        $('#loading:visible').on(eventPrefix + 'hide', function() {
+            updateSrsNames();
+        });
+    })();
+})();


### PR DESCRIPTION
This is somewhat related to #39 

This is a very popular userscript made by Seanblue that will show the specific SRS level after pass/fail in reviews ("apprentice 4" instead of "apprentice" for example)

I know you are preferring to not spend much time on userscripts, but this one is pretty small and low risk, and annoys me that I don't have it when doing reviews on my phone... And if anything, adding it serves as a reminder to implement this small but useful feature into the native reviewing 😄 